### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,45 @@
 # Cucumber Compatibility Kit
 
 The CCK - aka. Cucumber Compatibility Kit - is a set of features and Messages.
+It aims to validate an implementation of the
+[Cucumber Messages protocol](https://github.com/cucumber/common/tree/main/messages#cucumber-messages).
 
-It aims to validate an implementation of the [Cucumber Messages protocol](https://github.com/cucumber/common/tree/main/messages#cucumber-messages).
-
-For example, [cucumber-ruby](https://github.com/cucumber/cucumber-ruby/blob/main/spec/cck/cck_spec.rb) and [cucumber-js](https://github.com/cucumber/cucumber-js/blob/main/compatibility/cck_spec.ts) are using it to make sure they emmit well-formed Messages when executing the features from the kit.
+For example, [cucumber-ruby](https://github.com/cucumber/cucumber-ruby/blob/main/spec/cck/cck_spec.rb)
+and [cucumber-js](https://github.com/cucumber/cucumber-js/blob/main/compatibility/cck_spec.ts)
+are using it to make sure they emmit well-formed Messages when executing the
+features from the kit.
 
 ## Overview
 
 The kit is composed of features, step definitions, and messages:
 
-- features, once executed, emit an exhaustive set of Messages as specified by the protocol
+- features, once executed, emit an exhaustive set of Messages as specified b
+  the protocol
 - step definitions allows to execute the features of the kit as expected
-- Messages - serialized as `.ndjson` files - are the reference: a given feature from the kit, executed using its dedicated step definitions, must emit the corresponding Messages
+- Messages - serialized as `.ndjson` files - are the reference: a given feature
+  from the kit, executed using its dedicated step definitions, must emit the
+  corresponding Messages
 
-The Messages from the kit are generated using [fake-cucumber](https://github.com/cucumber/fake-cucumber), which is used here as a reference implementation of the Messages protocol.
+The Messages from the kit are generated using
+[fake-cucumber](https://github.com/cucumber/fake-cucumber), which is used here
+as a reference implementation of the Messages protocol.
 
 ## Contributing
 
-This repo is composed of a [devkit](./devkit/), and packages to deliver the kit using managers like npm or rubygem.
+This repo is composed of a [devkit](./devkit/), and packages to deliver the kit
+using managers like npm or rubygem.
 
 ### The devkit
 
-The [devkit](./devkit/) is a set of tools to generate new Messages in order to extend the kit, or to update it after the protocol has been changed.
+The [devkit](./devkit/) is a set of tools to generate new Messages in order to
+extend the kit, or to update it after the protocol has been changed.
 
 ### The packages
 
 At the moment, there are two packages: a NPM one, and a ruby gem.
 
-The [NPM package](./javascript/) bundles the kit with step definitions implemented in TypeScript.
-
-The [ruby gem](./ruby), in addition of the kit and its step definitions written in ruby, also provides a few helpers to make it easier to work with the CCK.
+- the [NPM package](./javascript/) bundles the kit with step definitions
+  implemented in TypeScript.
+- the [ruby gem](./ruby), in addition of the kit and its step definitions
+  written in ruby, also provides a few helpers to make it easier to work with
+  the CCK.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Cucumber Compatibility Kit
 
-The CCK - aka. Cucumber Compatibility Kit - is a set of features and Messages.
-It aims to validate an implementation of the
+The Cucumber Compatibility Kit (CCK) aims to validate a Cucumber implementation's support for the
 [Cucumber Messages protocol](https://github.com/cucumber/common/tree/main/messages#cucumber-messages).
 
 For example, [cucumber-ruby](https://github.com/cucumber/cucumber-ruby/blob/main/spec/cck/cck_spec.rb)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 The CCK - aka. Cucumber Compatibility Kit - is a set of features and Messages.
 
-It aims to validate an implementation of the Cucumber Messages protocol.
+It aims to validate an implementation of the [Cucumber Messages protocol](https://github.com/cucumber/common/tree/main/messages#cucumber-messages).
 
-For example, cucumber-ruby and cucumber-js are using it to make sure they emmit well-formed Messages when executing the features from the kit.
+For example, [cucumber-ruby](https://github.com/cucumber/cucumber-ruby/blob/main/spec/cck/cck_spec.rb) and [cucumber-js](https://github.com/cucumber/cucumber-js/blob/main/compatibility/cck_spec.ts) are using it to make sure they emmit well-formed Messages when executing the features from the kit.
 
 ## Overview
 
@@ -12,22 +12,22 @@ The kit is composed of features, step definitions, and messages:
 
 - features, once executed, emit an exhaustive set of Messages as specified by the protocol
 - step definitions allows to execute the features of the kit as expected
-- Messages - serialized as .ndjson files - are the reference: a given feature from the kit, executed using its dedicated step definitions, must emit the corresponding messages
+- Messages - serialized as `.ndjson` files - are the reference: a given feature from the kit, executed using its dedicated step definitions, must emit the corresponding Messages
 
-The Messages from the kit are generated using fake-cucumber, which is used here as a reference implementation of the Messages protocol.
+The Messages from the kit are generated using [fake-cucumber](https://github.com/cucumber/fake-cucumber), which is used here as a reference implementation of the Messages protocol.
 
 ## Contributing
 
-This repo is composed of a devkit, and packages to deliver the kit using package managers like npm or rubygem.
+This repo is composed of a [devkit](./devkit/), and packages to deliver the kit using managers like npm or rubygem.
 
 ### The devkit
 
-The devkit is a set of tools to generate new Messages to extend the kit, or to update it after the protocol has been changed.
+The [devkit](./devkit/) is a set of tools to generate new Messages in order to extend the kit, or to update it after the protocol has been changed.
 
 ### The packages
 
 At the moment, there are two packages: a NPM one, and a ruby gem.
 
-The NPM package bundles the kit with step definitions implemented in TypeScript.
+The [NPM package](./javascript/) bundles the kit with step definitions implemented in TypeScript.
 
-The ruby gem, in addition of the kit and its step definitions written in ruby, also provides a few helpers to make it easier to work with the CCK.
+The [ruby gem](./ruby), in addition of the kit and its step definitions written in ruby, also provides a few helpers to make it easier to work with the CCK.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ For example, cucumber-ruby and cucumber-js are using it to make sure they emmit 
 
 The kit is composed of features, step definitions, and messages:
 
-- features, once executed, emit an exhaustive set of Messages definfed by the protocol.
-- step definitions allows to execute the features of the kit as expected.
-- Messages - serialized as .ndjson files - are the reference: a given feature from the kit, executed using its dedicated step definitions, must emit the corresponding messages.
+- features, once executed, emit an exhaustive set of Messages as specified by the protocol
+- step definitions allows to execute the features of the kit as expected
+- Messages - serialized as .ndjson files - are the reference: a given feature from the kit, executed using its dedicated step definitions, must emit the corresponding messages
 
 The Messages from the kit are generated using fake-cucumber, which is used here as a reference implementation of the Messages protocol.
 
@@ -28,6 +28,6 @@ The devkit is a set of tools to generate new Messages to extend the kit, or to u
 
 At the moment, there are two packages: a NPM one, and a ruby gem.
 
-The NPM package bundles nothing more than the compatibility kit with step definitions implemented in TypeScript.
+The NPM package bundles the kit with step definitions implemented in TypeScript.
 
 The ruby gem, in addition of the kit and its step definitions written in ruby, also provides a few helpers to make it easier to work with the CCK.

--- a/README.md
+++ b/README.md
@@ -1,88 +1,33 @@
 # Cucumber Compatibility Kit
 
-The CCK is a platform agnostic set of acceptance tests for validating a Cucumber
-implementation.
+The CCK - aka. Cucumber Compatibility Kit - is a set of features and Messages.
+
+It aims to validate an implementation of the Cucumber Messages protocol.
+
+For example, cucumber-ruby and cucumber-js are using it to make sure they emmit well-formed Messages when executing the features from the kit.
 
 ## Overview
 
-This test suite does not aim to use Cucumber to describe Cucumber. The Gherkin
-documents do not contain doc strings with other Gherkin documents and support code.
-It's not that meta. (That style has been used for older Cucumber implementations.
-It's clunky to deal with).
+The kit is composed of features, step definitions, and messages:
 
-This test suite is just a set of plain gherkin documents (feature files) and
-support code (step definitions and hooks).
+- features, once executed, emit an exhaustive set of Messages definfed by the protocol.
+- step definitions allows to execute the features of the kit as expected.
+- Messages - serialized as .ndjson files - are the reference: a given feature from the kit, executed using its dedicated step definitions, must emit the corresponding messages.
 
-The test suite *exercises* various features of Cucumber (hopefully all of them).
-For example there is a feature with some tags and we're verifying that only some
-of them are executed.
+The Messages from the kit are generated using fake-cucumber, which is used here as a reference implementation of the Messages protocol.
 
-The "golden master" is based on `fake-cucumber` (maybe to be renamed to something
-more official-sounding), where the support code is implemented in TypeScript.
+## Contributing
 
-In order to use the TCK with another Cucumber implementation, this TypeScript
-support code must be ported to the target platform. Then, if the implementation is
-compliant, it will output messages that are equivalent to the golden master.
+This repo is composed of a devkit, and packages to deliver the kit using package managers like npm or rubygem.
 
-We say equivalent, because we allow certain fields to be different from the golden
-master:
+### The devkit
 
-* `SourceReference` fields used in support code messages
-* `Duration` and `Timestamp` fields
-* `id` fields
-* `StackTrace` fields (todo: new message)
+The devkit is a set of tools to generate new Messages to extend the kit, or to update it after the protocol has been changed.
 
-These fields are normalised before comparison using `JSON.parse` with a custom
-reviver.
+### The packages
 
-The test suite doesn't make assertions *about* the messages, it just compares them.
-The messages for the golden master should be inspected manually before being committed.
+At the moment, there are two packages: a NPM one, and a ruby gem.
 
-## Packaging
+The NPM package bundles nothing more than the compatibility kit with step definitions implemented in TypeScript.
 
-The `cucumber-cck` module is packaged and distributed in several formats (currently
-rubygem, jar and NPM module). The module contains the following files:
-
-* `.feature` files (input)
-* `.ndjson` files (expected output)
-
-The validation can be done with the `cucumber-cck` CLI, which performs the normalisation
-described above, and compares the expected output to the actual output and generates a report.
-
-## Reporting
-
-Compliance with the CCK isn't all or nothing. Partial compliance is possible.
-The `cucumber-cck` can be passed two directories (containing expected and actual message files),
-and it will produce a `cucumber-cck.json` document describing the compliance level.
-
-A Markdown file or other presentation format can be generated from multiple `cucumber-cck.json`
-files (for multiple implementations). This provides user as well as contributors
-with an overview of what's implemented, and what still needs some work.
-
-## What's tested
-
-See https://app.mindmup.com/map/_v2/2b5ee9a00d1b11ea85574541c004362d
-
-## Regenerating the Golden NDJSONs
-
-The messages produced by `fake-cucumber` are stored in GIT. You can generate them again by running:
-
-```shell
-GOLDEN=1 make
-```
-
-## Configuration
-
-The CCK works by comparing the golden master NDJSON files against files generated
-by the Cucumber implementation being tested. This means we need to remove any
-unpredictability from the output such as:
-
-* Random messages ids (UUIDs)
-* Unpredictable timestamps and durations
-* Platform-specific error messages (stack traces)
-
-To enable this we specify the `--cck` option, which will:
-* Use predictable ids (a counter starting at 1)
-* Use a clock that starts on 1000000 millis and increments by 1ms each time it is asked.
-  All durations are 1ms.
-* Renders errors with only the error message, and not the stack trace.
+The ruby gem, in addition of the kit and its step definitions written in ruby, also provides a few helpers to make it easier to work with the CCK.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ features from the kit.
 
 The kit is composed of features, step definitions, and messages:
 
-- features, once executed, emit an exhaustive set of Messages as specified b
+- features, once executed, emit an exhaustive set of Messages as specified by
   the protocol
 - step definitions allows to execute the features of the kit as expected
 - Messages - serialized as `.ndjson` files - are the reference: a given feature

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ as a reference implementation of the Messages protocol.
 ## Contributing
 
 This repo is composed of a [devkit](./devkit/), and packages to deliver the kit
-using managers like npm or rubygem.
+using managers like NPM or rubygem.
 
 ### The devkit
 

--- a/devkit/README.md
+++ b/devkit/README.md
@@ -1,0 +1,67 @@
+# Cucumber Compatibility Kit: the Devkit
+
+This devkit is a set of NPM scripts to generate new Messages in order to
+extend the Cucumber Compatibility Kit, or to update it after the protocol has
+been changed.
+
+## Getting Started
+
+As any NPM project, you first need to run `npm install`. To make sure everything
+is going well, run `npm test`.
+
+## Contributing to the Compability Kit
+
+The files delivered as part ot fhe kit - the feature files and the ndjson files -
+can be found in the [`samples`](./samples) folder.
+
+The [`src`](.src) folder contains source code used by the NPM scripts of the devkit.
+For example it contains a [`validate.ts`](./samples/validate.ts) file which is
+used by the `test` NPM script. That `test` script make sure the `.ndjson` files
+are valid regarding the schema of the Cucumber Messages protocol.
+
+### Adding a new feature
+
+To add a new feature in the kit, create a new folder in [`samples`](./samples).
+Put the feature here, and its step definitions implemented in TypeScript, and
+any required assets like pictures that would be used as attachements for example.
+
+Once your feature is ready, you can generate the messages.
+
+### Generating the Messages
+
+Once you have added a new feature or updated an existing one, or if you need
+to regenerate the Messages due to an update in the Messages protocol, run the
+following script:
+
+    npm run generate-ndjson
+
+That will update the `.ndjson` files of the kit. It will also validate those
+files against the json schema of the Messages protocol, and copy all samples
+(including the features, the step definitions, the assets, and the messages)
+in the packages.
+
+After reviewing the `git diff`, you can commit and push the changes into a new
+pull request for review.
+
+#### Note regarding the packages
+
+The packages have specific instructions into `.gitignore` to ignore the files
+of the kit like features or messages.
+
+After updating the samples in the devkit, you won't notice any changes in the
+ruby package. You will have to report updates to the step definitions manually.
+
+However regarding the JavaScript package, you won't notice any changes either,
+and you won't have to report changes to the step definitions. The one from the
+devkit will be automatically copied there.
+
+### NPM scripts available
+
+The main NPM scripts available are:
+
+- build: it build TypeScript files in `src` into JavaScript files in `dist`
+- test: validate each `.ndjson` file against json schema of the Messages protocol
+- generate-ndjson: generate messages and serialize them as `.ndjson` for the
+  features and using the step definitions of the `samples` folder
+- copy-samples: copy the samples into the packages. Will also copy the step
+  definition into the JavaScript package

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -1,0 +1,63 @@
+# Cucumber Compatibility Kit
+
+The CCK - aka. Cucumber Compatibility Kit - is a set of features and Messages.
+It aims to validate an implementation of the
+[Cucumber Messages protocol](https://github.com/cucumber/common/tree/main/messages#cucumber-messages).
+
+## Overview
+
+The kit is composed of features and messages:
+
+- features, once executed, emit an exhaustive set of Messages as specified by
+  the protocol
+- Messages - serialized as `.ndjson` files - are the reference: a given feature
+  from the kit, executed using its dedicated step definitions, must emit the
+  corresponding Messages
+
+## Getting Started
+
+After running `npm install --save-dev @cucumber/compatibility-kit`, the kit is
+available in your `node_modules` in `node_modules/@cucumber/compatibility-kit/features`.
+
+You will find there some folders. Each folder owns a feature with its corresponding Messages.
+
+### The features
+
+You can execute the features with your implementation. For example with cucumber, it
+would look like the following:
+
+    npx cucumber-js node_modules/@cucumber/compatibility-kit/features/**/*.feature
+
+Here's we have been able to run our features. However it did not find the step
+definitions. It is up to you to implement your step definitions compatible
+with your own tool.
+
+In order to make some experiments, the kit comes with step definitions compatible with
+[fake-cucumber](https://github.com/cucumber/fake-cucumber) and written using TypeScript.
+You will find also a few assets which may be required for some features. For example,
+the `attachments` feature is using an asset `cucumber.png` to test the possibility
+to attach images to the Messages.
+
+### The Messages
+
+Each feature available in the kit comes with a `.ndjson`. That file is the expected
+Messages related the execution of the corresopnding feature. For convenience, the
+messages are serialized using the [ndjson](http://ndjson.org/) format.
+
+The idea is to execute the features of the kit using your tool, to generate the
+corresponding messages, and to compare your messages with the ones from the kit.
+
+## More info
+
+The Cucumber Compatibility Kit is part of the development tools of [Cucumber](https://cucumber.io).
+It allows us to make sure that all our implementations are properly supporting our internal protocol
+and thus are compabitle with each other and with our common tools like the [html-formatter](https://github.com/cucumber/html-formatter).
+
+It can be a valuable tool if you are developing integration with cucumber, or your
+own implementation of it.
+
+Join us on [github/cucumber/compatibility-kit](https://github.com/cucumber/compatibility-kit)
+to get more help if you need to.
+
+You can also take a look on [cucumber-js](https://github.com/cucumber/cucumber-js/blob/v8.3.1/compatibility/cck_spec.ts)
+to see how the kit is used there.

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -7,7 +7,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cucumber/cucumber.git"
+    "url": "git+https://github.com/cucumber/compatibility-kit.git"
   },
   "author": "Aslak Hellesøy",
   "license": "MIT",

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,12 +1,21 @@
 # The Cucumber Compatibility Kit for Ruby
 
-The Cucumber Compatibility Kit - or CCK - for ruby is a gem that aims to help validating
-an implementation of Cucumber.
+The CCK - aka. Cucumber Compatibility Kit - is a set of features and Messages.
+It aims to validate an implementation of the
+[Cucumber Messages protocol](https://github.com/cucumber/common/tree/main/messages#cucumber-messages).
 
-It provides a set of features and the expected messages related to those features.
+## Overview
 
-It also provides some tools to help in the validation of messages issued from the
-execution of the CCK's features.
+The kit is composed of features and messages:
+
+- features, once executed, emit an exhaustive set of Messages as specified by
+  the protocol
+- Messages - serialized as `.ndjson` files - are the reference: a given feature
+  from the kit, executed using its dedicated step definitions, must emit the
+  corresponding Messages
+
+The ruby gem also provides some tools to help in the validation of messages issued
+from the execution of the CCK's features.
 
 ## Installation and Usage
 
@@ -54,3 +63,18 @@ required to execute the given example. As we use the `--format message` formatte
 You can use `gem open cucumber-compatibility-kit` in order to take a look on the
 features, their support code, and the expected messages.They are available in the
 `features` folder within the gem.
+
+## More info
+
+The Cucumber Compatibility Kit is part of the development tools of [Cucumber](https://cucumber.io).
+It allows us to make sure that all our implementations are properly supporting our internal protocol
+and thus are compabitle with each other and with our common tools like the [html-formatter](https://github.com/cucumber/html-formatter).
+
+It can be a valuable tool if you are developing integration with cucumber, or your
+own implementation of it.
+
+Join us on [github/cucumber/compatibility-kit](https://github.com/cucumber/compatibility-kit)
+to get more help if you need to.
+
+You can also take a look on [cucumber-ruby](https://github.com/cucumber/cucumber-ruby/blob/v8.0.0/spec/cck/cck_spec.rb)
+to see how the kit is used there.

--- a/ruby/cucumber-compatibility-kit.gemspec
+++ b/ruby/cucumber-compatibility-kit.gemspec
@@ -7,17 +7,17 @@ Gem::Specification.new do |s|
   s.description = 'Kit to check compatibility with official cucumber implementation'
   s.summary     = "#{s.name}-#{s.version}"
   s.email       = 'cukebot@cucumber.io'
-  s.homepage    = 'https://github.com/cucumber/common'
+  s.homepage    = 'https://github.com/cucumber/compatibility-kit'
   s.platform    = Gem::Platform::RUBY
   s.license     = 'MIT'
   s.required_ruby_version = '>= 2.3'
 
   s.metadata = {
-    'bug_tracker_uri' => 'https://github.com/cucumber/common/issues',
-    'changelog_uri' => 'https://github.com/cucumber/common/blob/main/compatibility-kit/CHANGELOG.md',
+    'bug_tracker_uri' => 'https://github.com/cucumber/compatibility-kit/issues',
+    'changelog_uri' => 'https://github.com/cucumber/compatibility-kit/blob/main/compatibility-kit/CHANGELOG.md',
     'documentation_uri' => 'https://cucumber.io/docs/gherkin/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/cukes',
-    'source_code_uri' => 'https://github.com/cucumber/common/blob/main/compatibility-kit/ruby'
+    'source_code_uri' => 'https://github.com/cucumber/compatibility-kit/blob/main/ruby'
   }
 
   s.add_dependency 'cucumber-messages', '~> 19.0', '>= 19.0.0'


### PR DESCRIPTION
Update of the documentation of the CCK as it has changed a lot since the actual readme has been last updated.

- [x] Update root readme as an introduction to the cck
- [x] Add a readme in the devkit folder to explain how to work with it to update the kit
- [x] Add a readme in javascript for the npm page of the kit
- [x] Add a readme in ruby
- [x] Update info in package.json for the npm page
- [x] Update info in gemspec for the rubygem page