### PR TITLE
chore: add docs for adoption

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing
 
 This repo is composed of a [devkit](./devkit/), and packages to deliver the kit
-using managers like NPM or rubygem.
+using managers like NPM or rubygems.
 
 ## The devkit
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing
+
+This repo is composed of a [devkit](./devkit/), and packages to deliver the kit
+using managers like NPM or rubygem.
+
+## The devkit
+
+The [devkit](./devkit/) is a set of tools to generate new Messages in order to
+extend the kit, or to update it after the protocol has been changed.
+
+## The packages
+
+At the moment, there are two packages: a npm one, and a ruby gem.
+
+- the [npm package](./javascript/) bundles the kit with step definitions
+  implemented in TypeScript.
+- the [ruby gem](./ruby), in addition of the kit and its step definitions
+  written in ruby, also provides a few helpers to make it easier to work with
+  the CCK.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cucumber Compatibility Kit
 
 The Cucumber Compatibility Kit (CCK) aims to validate a Cucumber implementation's support for the
-[Cucumber Messages protocol](https://github.com/cucumber/common/tree/main/messages#cucumber-messages).
+[Cucumber Messages protocol](https://github.com/cucumber/messages).
 
 For example, [cucumber-ruby](https://github.com/cucumber/cucumber-ruby/blob/main/spec/cck/cck_spec.rb)
 and [cucumber-js](https://github.com/cucumber/cucumber-js/blob/main/compatibility/cck_spec.ts)
@@ -12,10 +12,9 @@ features from the kit.
 
 The kit is composed of features, step definitions, and messages:
 
-- features, once executed, emit an exhaustive set of Messages as specified by
-  the protocol
-- step definitions allows to execute the features of the kit as expected
-- Messages - serialized as `.ndjson` files - are the reference: a given feature
+- **features**, once executed, emit an exhaustive set of Messages as specified by the protocol
+- **step definitions** that are used in conjunction with the features to generate the Messages, and also serve as reference step definitions for implementations adopting the kit
+- **Messages**, serialized as `.ndjson` files, are the reference: a given feature
   from the kit, executed using its dedicated step definitions, must emit the
   corresponding Messages
 
@@ -23,22 +22,39 @@ The Messages from the kit are generated using
 [fake-cucumber](https://github.com/cucumber/fake-cucumber), which is used here
 as a reference implementation of the Messages protocol.
 
-## Contributing
+## Adoption
 
-This repo is composed of a [devkit](./devkit/), and packages to deliver the kit
-using managers like NPM or rubygem.
+To adopt the compatibility kit when writing a Cucumber implementation:
 
-### The devkit
+### Prerequisites
 
-The [devkit](./devkit/) is a set of tools to generate new Messages in order to
-extend the kit, or to update it after the protocol has been changed.
+First, make sure your implementation is sufficiently testable - you should be able to execute a test run programatically for a given set of feature files and step definitions, and get a handle on the Messages output (via a formatter or some other means) to make assertions on.
 
-### The packages
+### Setup
 
-At the moment, there are two packages: a NPM one, and a ruby gem.
+Pull in the latest version of the CCK package for your platform. If there isn't one yet, consider just copying over the files you need from the [devkit](./devkit/) for now - you can figure out the publishing later once it's all working.
 
-- the [NPM package](./javascript/) bundles the kit with step definitions
-  implemented in TypeScript.
-- the [ruby gem](./ruby), in addition of the kit and its step definitions
-  written in ruby, also provides a few helpers to make it easier to work with
-  the CCK.
+Next, for each feature in the CCK suite, write step definitions that work with your implementation - these should be _equivalent_ to the reference step definitions from the devkit, but with the appropriate language, syntax etc.
+
+### Testing
+
+Now you can build your CCK test. For each feature in the CCK suite, it should:
+
+1. Execute a test run, scoped to:
+  - Only the feature file in question
+  - Only the step definition file that you wrote for this feature
+2. Capture the Messages output of that test run
+3. Load the reference messages from the `.ndjson` file and assert that the output you captured matches it
+
+### Notes and exceptions
+
+When we say "matches" above, that's heavily qualified - there are many individual fields that will vary from run to run, like generated identifiers, timestamps, durations and file URLs. You can freely exclude these fields from your assertion - the key thing to capture is the number and order of the messages, and the content that would be consistent across runs. It's also not unheard of for implementations to fix up the order of messages so it matches the CCK, although it's best to try to match it naturally if you can.
+
+A small minority of features also have an `.arguments.txt` that specify additional arguments/options that are pertinent to the feature - see `retry` for an example. You can adapt these how you see fit - they may or may not line up directly with your CLI options schema.
+
+There may be some features in the CCK suite that cover functionality that your implementation doesn't have. For example, there's one for `retry` which only a subset of Cucumbers support. You can filter these out of your test until/unless you're ready to support them.
+
+### Existing implementations
+
+- [`cucumber-js`](https://github.com/cucumber/cucumber-js/tree/main/compatibility)
+- [`cucumber-jvm`](https://github.com/cucumber/cucumber-jvm/tree/main/compatibility)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ as a reference implementation of the Messages protocol.
 
 ## Adoption
 
-To adopt the compatibility kit when writing a Cucumber implementation, an implementer must:
+To adopt the compatibility kit when writing a Cucumber implementation, an implementer must have some prerequisites, do some setup in the implementation project and then write a dynamic test that is fed by the kit.
 
 ### Prerequisites
 
@@ -48,7 +48,9 @@ Now you can build your CCK test. For each feature in the CCK suite, it should:
 
 ### Notes and exceptions
 
-When we say "matches" above, that's heavily qualified - there are many individual fields that will vary from run to run, like generated identifiers, timestamps, durations and file URLs. You can freely exclude these fields from your assertion - the key thing to capture is the number and order of the messages, and the content that would be consistent across runs. It's also not unheard of for implementations to fix up the order of messages so it matches the CCK, although it's best to try to match it naturally if you can.
+When we say "matches" above, that's heavily qualified - there are many individual fields that will vary from run to run, like generated identifiers, timestamps, durations and file URLs. You can freely exclude these fields from your assertion - the key thing to capture is the number, type and order of the messages, and the content that would be consistent across runs. It's also not unheard of for implementations to fix up the order of messages so it matches the CCK, although it's best to try to match it naturally if you can.
+
+Bear in mind that if you, for example, omit or mis-type a step definition, the failure you get might be non-obvious e.g. a discrepancy between actual and expected messages. Many of the features in the CCK represent a test run that fails, so this is not something that should cause your test to fail, although you might find it useful to capture the stderr (or equivalent) output for debugging purposes.
 
 A small minority of features also have an `.arguments.txt` that specify additional arguments/options that are pertinent to the feature - see `retry` for an example. You can adapt these how you see fit - they may or may not line up directly with your CLI options schema.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The kit is composed of features, step definitions, and messages:
 - **features**, once executed, emit an exhaustive set of Messages as specified by the protocol
 - **step definitions** that are used in conjunction with the features to generate the Messages, and also serve as reference step definitions for implementations adopting the kit
 - **Messages**, serialized as `.ndjson` files, are the reference: a given feature
-  from the kit, executed using its dedicated step definitions, must emit the
+  from the kit, executed using its dedicated step definitions, **must** emit the
   corresponding Messages
 
 The Messages from the kit are generated using
@@ -24,11 +24,11 @@ as a reference implementation of the Messages protocol.
 
 ## Adoption
 
-To adopt the compatibility kit when writing a Cucumber implementation:
+To adopt the compatibility kit when writing a Cucumber implementation, an implementer must:
 
 ### Prerequisites
 
-First, make sure your implementation is sufficiently testable - you should be able to execute a test run programatically for a given set of feature files and step definitions, and get a handle on the Messages output (via a formatter or some other means) to make assertions on.
+First, make sure your implementation is sufficiently testable - you should be able to execute a test run programatically for a given set of feature files and step definitions, and obtain the Messages output (via a formatter or some other means) to make assertions on.
 
 ### Setup
 
@@ -52,7 +52,7 @@ When we say "matches" above, that's heavily qualified - there are many individua
 
 A small minority of features also have an `.arguments.txt` that specify additional arguments/options that are pertinent to the feature - see `retry` for an example. You can adapt these how you see fit - they may or may not line up directly with your CLI options schema.
 
-There may be some features in the CCK suite that cover functionality that your implementation doesn't have. For example, there's one for `retry` which only a subset of Cucumbers support. You can filter these out of your test until/unless you're ready to support them.
+There may be some features in the CCK suite that cover functionality that your implementation doesn't have. For example, there's one for `retry` which only a subset of Cucumber implementations support. You can filter these out of your test until/unless you're ready to support them.
 
 ### Existing implementations
 


### PR DESCRIPTION
### 🤔 What's changed?

Add a section to the README about how to adopt the compatibility kit in your Cucumber implementation. Move the contributing docs to the standard file for clarity.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
