### PR TITLE
Ruby: ignore meta ci messages in testing

### DIFF
--- a/ruby/lib/keys_checker.rb
+++ b/ruby/lib/keys_checker.rb
@@ -12,11 +12,13 @@ module CCK
 
       return errors if found_keys.sort == expected_keys.sort
 
-      missing_keys = (expected_keys - found_keys)
-
-      extra_keys = (found_keys - expected_keys).reject { |key|
+      missing_keys = (expected_keys - found_keys).reject do |key|
         ENV['CI'] && found.class == Cucumber::Messages::Meta && key == :ci
-      }
+      end
+
+      extra_keys = (found_keys - expected_keys).reject do |key|
+        ENV['CI'] && found.class == Cucumber::Messages::Meta && key == :ci
+      end
 
       errors << "Found extra keys in message #{found.class.name}: #{extra_keys}" unless extra_keys.empty?
       errors << "Missing keys in message #{found.class.name}: #{missing_keys}" unless missing_keys.empty?

--- a/ruby/lib/keys_checker.rb
+++ b/ruby/lib/keys_checker.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module CCK
   class KeysChecker
     def self.compare(found, expected)
@@ -13,11 +14,11 @@ module CCK
       return errors if found_keys.sort == expected_keys.sort
 
       missing_keys = (expected_keys - found_keys).reject do |key|
-        ENV['CI'] && found.class == Cucumber::Messages::Meta && key == :ci
+        found.instance_of?(Cucumber::Messages::Meta) && key == :ci
       end
 
       extra_keys = (found_keys - expected_keys).reject do |key|
-        ENV['CI'] && found.class == Cucumber::Messages::Meta && key == :ci
+        found.instance_of?(Cucumber::Messages::Meta) && key == :ci
       end
 
       errors << "Found extra keys in message #{found.class.name}: #{extra_keys}" unless extra_keys.empty?

--- a/ruby/spec/messages_comparator_spec.rb
+++ b/ruby/spec/messages_comparator_spec.rb
@@ -10,12 +10,25 @@ describe CCK::MessagesComparator do
       allow(ENV).to receive(:[]).with('CI').and_return(true)
     end
 
-    it 'ignores actual CI related messages' do
+    it 'ignores extra found CI messages' do
       found_message_ci = Cucumber::Messages::Ci.new(name: 'Some CI')
       found_message_meta = Cucumber::Messages::Meta.new(ci: found_message_ci)
       found_message_envelope = Cucumber::Messages::Envelope.new(meta: found_message_meta)
 
       expected_message_meta = Cucumber::Messages::Meta.new()
+      expected_message_envelope = Cucumber::Messages::Envelope.new(meta: expected_message_meta)
+
+      comparator = subject.new(CCK::KeysChecker, [found_message_envelope], [expected_message_envelope])
+
+      expect(comparator.errors).to be_empty
+    end
+
+    it 'ignores extra expected CI messages' do
+      found_message_meta = Cucumber::Messages::Meta.new()
+      found_message_envelope = Cucumber::Messages::Envelope.new(meta: found_message_meta)
+
+      expected_message_ci = Cucumber::Messages::Ci.new(name: 'Some CI')
+      expected_message_meta = Cucumber::Messages::Meta.new(ci: expected_message_ci)
       expected_message_envelope = Cucumber::Messages::Envelope.new(meta: expected_message_meta)
 
       comparator = subject.new(CCK::KeysChecker, [found_message_envelope], [expected_message_envelope])


### PR DESCRIPTION
### 🤔 What's changed?

Add a test and new functionality to ignore **both** extra and missing keys that are of the Meta Envelope

### ⚡️ What's your motivation? 

Fixes #41 

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)
- 
### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
