### PR TITLE
Ruby: Fix CCK only reporting messages as `attachment`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - [Ruby] The `meta` key was being erroneously checked when running CCK tests ([#43](https://github.com/cucumber/compatibility-kit/pull/43))
+- [Ruby] All messages were being analysed as `attachment` when running CCK tests ([#45](https://github.com/cucumber/compatibility-kit/pull/45))
 
 ## [12.0.0] - 2023-07-08
 ### Changed

--- a/ruby/lib/shared_examples.rb
+++ b/ruby/lib/shared_examples.rb
@@ -45,7 +45,10 @@ def parse_ndjson(ndjson)
 end
 
 def message_type(message)
-  message.to_h.keys.first
+  # TODO: This is duplicate code - from messages_comparator:45 - It should live in a common helper methods module
+  message.to_h.each do |key, value|
+    return key unless value.nil?
+  end
 end
 
 def debug_lists(expected, obtained)


### PR DESCRIPTION
Fix situation where the message types were all being flagged as `attachment`

### 🤔 What's changed?

Fix #39 

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

New sample output
```
0> original_messages_types
=> [:meta, :source, :gherkin_document, :pickle, :pickle, :pickle, :pickle, :pickle, :pickle, :pickle, :pickle, :step_definition, :step_definition, :step_definition, :step_definition, :step_definition, :step_definition, :step_definition, :step_definition, :step_definition, :hook, :test_run_started, :test_case, :test_case, :test_case, :test_case, :test_case, :test_case, :test_case, :test_case, :test_case_started, :test_step_started, :test_step_finished, :test_step_started, :attachment, :test_step_finished, :test_case_finished, :test_case_started, :test_step_started, :test_step_finished, :test_step_started, :attachment, :test_step_finished, :test_case_finished, :test_case_started, :test_step_started, :test_step_finished, :test_step_started, :attachment, :test_step_finished, :test_case_finished, :test_case_started, :test_step_started, :test_step_finished, :test_step_started, :attachment, :test_step_finished, :test_case_finished, :test_case_started, :test_step_started, :test_step_finished, :test_step_started, :attachment, :test_step_finished, :test_case_finished, :test_case_started, :test_step_started, :test_step_finished, :test_step_started, :attachment, :test_step_finished, :test_case_finished, :test_case_started, :test_step_started, :test_step_finished, :test_step_started, :attachment, :test_step_finished, :test_case_finished, :test_case_started, :test_step_started, :test_step_finished, :test_step_started, :attachment, :test_step_finished, :test_case_finished, :test_run_finished]
```

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
