### PR TITLE
[Ruby]: Fix #attach_or_embed to work with var args

### DIFF
--- a/ruby/features/attachments/attachments.feature.rb
+++ b/ruby/features/attachments/attachments.feature.rb
@@ -7,9 +7,9 @@ Before do
   # no-op
 end
 
-def attach_or_embed(world, data, media_type)
+def attach_or_embed(world, data, media_type, filename = nil)
   # Backward compatibility as the steps are also used by cucumber-ruby 3 which does not support `attach`
-  world.respond_to?(:attach) ? attach(data, media_type) : embed(data, media_type)
+  world.respond_to?(:attach) ? attach(data, media_type, filename) : embed(data, media_type)
 end
 
 When('the string {string} is attached as {string}') do |text, media_type|


### PR DESCRIPTION
For filename attachments we need to pass in a custom filename occassionally, so duplicate the  name or pass in the name

### 🤔 What's changed?

Fixes an issue I forgot to fix in the big cck conformance changes

Not fixing `#embed` usage as this will be removed at some point soon as we look to couple the cck to a few versions of ruby

### ⚡️ What's your motivation? 

<!-- 
What motivated you to propose this change? Does it fix a bug? Add a new feature?
If it fixes an open issue, you can link to the issue here, e.g. "Fixes #99"
-->

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
