### PR TITLE
CCK: reconcile stack-traces

### DIFF
--- a/devkit/samples/stack-traces/stack-traces.feature
+++ b/devkit/samples/stack-traces/stack-traces.feature
@@ -1,11 +1,9 @@
 Feature: Stack traces
-  Nothing beats stack traces when it comes to diagnosing the source of a bug.
-  Cucumber provides helpful stack traces that:
-  
-  - Include a stack frame from the Gherkin document
-  - Remove uninteresting frames by default
+  Stack traces can help you diagnose the source of a bug.
+  Cucumber provides helpful stack traces that includes the stack frames from the
+  Gherkin document and remove uninteresting frames by default
 
-  The first line of the stack trace must contain the feature file.
+  The first line of the stack trace will contain a reference to the feature file.
 
   Scenario: A failing step
     When a step throws an exception

--- a/ruby/features/stack-traces/stack-traces.feature.rb
+++ b/ruby/features/stack-traces/stack-traces.feature.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 When('a step throws an exception') do
-  raise StandardError, 'An exception is raised here'
+  raise 'BOOM'
 end


### PR DESCRIPTION
### 🤔 What's changed?

`stack-traces` now is consistent for ruby/js

### ⚡️ What's your motivation? 

Goes towards completion of issue in tracker

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

Do we need to fix anything else (I'm deliberately not regenerating the ndjson yet because there are a bunch of these that will need re-generating each time). 

To avoid conflicts I'll re-generate once after merging several of these fixes

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
