### PR TITLE
[Ruby] bugfix: Don't check `git` sub-messages

### DIFF
--- a/ruby/lib/cck/messages_comparator.rb
+++ b/ruby/lib/cck/messages_comparator.rb
@@ -56,9 +56,9 @@ module CCK
       return if ignorable_time_message?(detected, expected)
       return if ci_message?(detected, expected)
       return if git_message?(detected, expected)
-
-      @compared << detected.class.name
+      
       @all_errors << @validator.compare(detected, expected)
+      @compared << detected.class.name
       compare_sub_messages(detected, expected)
     end
 

--- a/ruby/lib/cck/messages_comparator.rb
+++ b/ruby/lib/cck/messages_comparator.rb
@@ -75,12 +75,7 @@ module CCK
     end
 
     def ci_message?(detected, expected)
-      if detected.is_a?(Cucumber::Messages::Ci)
-        p "detected is: #{detected}"
-        p "expected is: #{expected}"
-        p "ENV['CI'] is: #{ENV['CI']}"
-        p(ENV['CI'] && detected.is_a?(Cucumber::Messages::Ci) && expected.nil?)
-      end
+      ENV['CI'] && detected.is_a?(Cucumber::Messages::Ci) && expected.nil?
     end
 
     def compare_sub_messages(detected, expected)

--- a/ruby/lib/cck/messages_comparator.rb
+++ b/ruby/lib/cck/messages_comparator.rb
@@ -55,6 +55,7 @@ module CCK
       return if ignorable_large_message?(detected)
       return if ignorable_time_message?(detected, expected)
       return if ci_message?(detected, expected)
+      return if git_message?(detected, expected)
 
       @compared << detected.class.name
       @all_errors << @validator.compare(detected, expected)
@@ -76,6 +77,15 @@ module CCK
 
     def ci_message?(detected, expected)
       ENV['CI'] && detected.is_a?(Cucumber::Messages::Ci) && expected.nil?
+    end
+
+    def git_message?(detected, expected)
+      if detected.is_a?(Cucumber::Messages::Git)
+        p "we got a git!!!"
+        p "detected is: #{detected.inspect}"
+        p "expected is: #{expected.inspect}"
+        true
+      end
     end
 
     def compare_sub_messages(detected, expected)

--- a/ruby/lib/cck/messages_comparator.rb
+++ b/ruby/lib/cck/messages_comparator.rb
@@ -51,14 +51,18 @@ module CCK
     end
 
     def compare_message(detected, expected)
-      return unless detected.is_a?(Cucumber::Messages::Message)
+      return if not_message?(detected)
       return if ignorable_large_message?(detected)
       return if ignorable_time_message?(detected, expected)
-      return if ENV['CI'] && detected.is_a?(Cucumber::Messages::Ci) && expected.nil?
+      return if ci_message?(detected, expected)
 
       @compared << detected.class.name
       @all_errors << @validator.compare(detected, expected)
       compare_sub_messages(detected, expected)
+    end
+
+    def not_message?(detected)
+      !detected.is_a?(Cucumber::Messages::Message)
     end
 
     def ignorable_large_message?(detected)
@@ -68,6 +72,15 @@ module CCK
     def ignorable_time_message?(detected, expected)
       (detected.is_a?(Cucumber::Messages::Timestamp) && expected.is_a?(Cucumber::Messages::Timestamp)) ||
         (detected.is_a?(Cucumber::Messages::Duration) && expected.is_a?(Cucumber::Messages::Duration))
+    end
+
+    def ci_message?(detected, expected)
+      if detected.is_a?(Cucumber::Messages::Ci)
+        p "detected is: #{detected}"
+        p "expected is: #{expected}"
+        p "ENV['CI'] is: #{ENV['CI']}"
+        p(ENV['CI'] && detected.is_a?(Cucumber::Messages::Ci) && expected.nil?)
+      end
     end
 
     def compare_sub_messages(detected, expected)

--- a/ruby/lib/cck/messages_comparator.rb
+++ b/ruby/lib/cck/messages_comparator.rb
@@ -56,7 +56,7 @@ module CCK
       return if ignorable_time_message?(detected, expected)
       return if ci_message?(detected, expected)
       return if git_message?(detected, expected)
-      
+
       @all_errors << @validator.compare(detected, expected)
       @compared << detected.class.name
       compare_sub_messages(detected, expected)
@@ -76,7 +76,7 @@ module CCK
     end
 
     def ci_message?(detected, expected)
-      ENV['CI'] && detected.is_a?(Cucumber::Messages::Ci) && expected.nil?
+      detected.is_a?(Cucumber::Messages::Ci)
     end
 
     def git_message?(detected, _expected)

--- a/ruby/lib/cck/messages_comparator.rb
+++ b/ruby/lib/cck/messages_comparator.rb
@@ -52,7 +52,7 @@ module CCK
 
     def compare_message(detected, expected)
       return if not_message?(detected)
-      return if ignorable?(detected, expected)
+      return if ignorable?(detected)
       return if incomparable?(detected)
 
       @all_errors << @validator.compare(detected, expected)
@@ -65,17 +65,16 @@ module CCK
     end
 
     # These messages we need to ignore because they are too large or they feature timestamps which always vary
-    def ignorable?(detected, expected)
-      too_large_message?(detected) || time_message?(detected, expected)
+    def ignorable?(detected)
+      too_large_message?(detected) || time_message?(detected)
     end
 
     def too_large_message?(detected)
       detected.is_a?(Cucumber::Messages::GherkinDocument) || detected.is_a?(Cucumber::Messages::Pickle)
     end
 
-    def time_message?(detected, expected)
-      (detected.is_a?(Cucumber::Messages::Timestamp) && expected.is_a?(Cucumber::Messages::Timestamp)) ||
-        (detected.is_a?(Cucumber::Messages::Duration) && expected.is_a?(Cucumber::Messages::Duration))
+    def time_message?(detected)
+      detected.is_a?(Cucumber::Messages::Timestamp) || detected.is_a?(Cucumber::Messages::Duration)
     end
 
     # These messages we need to ignore because they are often not of identical shape/value

--- a/ruby/lib/cck/messages_comparator.rb
+++ b/ruby/lib/cck/messages_comparator.rb
@@ -79,13 +79,8 @@ module CCK
       ENV['CI'] && detected.is_a?(Cucumber::Messages::Ci) && expected.nil?
     end
 
-    def git_message?(detected, expected)
-      if detected.is_a?(Cucumber::Messages::Git)
-        p "we got a git!!!"
-        p "detected is: #{detected.inspect}"
-        p "expected is: #{expected.inspect}"
-        true
-      end
+    def git_message?(detected, _expected)
+      detected.is_a?(Cucumber::Messages::Git)
     end
 
     def compare_sub_messages(detected, expected)


### PR DESCRIPTION
### 🤔 What's changed?

Fix a situation where we were incorrectly checking `Ci` messages
Don't check `Git` message properties, as these can vary (The NDJSON generation won't have a branch, but every CI run **will** have a branch)

### ⚡️ What's your motivation? 

Get cucumber-ruby conformant

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
