### PR TITLE
CCK: Reconcile cdata

### DIFF
--- a/devkit/samples/cdata/cdata.feature.ts
+++ b/devkit/samples/cdata/cdata.feature.ts
@@ -1,6 +1,5 @@
-import assert from 'assert'
 import { Given } from '@cucumber/fake-cucumber'
 
 Given('I have {int} <![CDATA[cukes]]> in my belly', function (cukeCount: number) {
-  assert(cukeCount)
+  // no-op
 })

--- a/ruby/features/cdata/cdata.feature.rb
+++ b/ruby/features/cdata/cdata.feature.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Given('I have {int} <![CDATA[cukes]]> in my belly') do |_cuke_count|
+  # no-op
+end


### PR DESCRIPTION
### 🤔 What's changed?

`cdata` now is consistent for ruby/js. NB: It was missing for ruby!

### ⚡️ What's your motivation? 

Goes towards completion of issue in tracker

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

Do we need to fix anything else (I'm deliberately not regenerating the ndjson yet because there are a bunch of these that will need re-generating each time). 

To avoid conflicts I'll re-generate once after merging several of these fixes

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
