### PR TITLE
CCK: Reconcile attachments

### DIFF
--- a/devkit/samples/attachments/attachments.feature
+++ b/devkit/samples/attachments/attachments.feature
@@ -30,11 +30,11 @@ Feature: Attachments
   Scenario: Byte arrays are base64-encoded regardless of media type
     When an array with 10 bytes is attached as "text/plain"
 
-  Scenario: Streams are always base64-encoded
+  Scenario: Attaching JPEG images
     When a JPEG image is attached
 
-  Scenario: Attaching images in examples
-    When the cucumber.png png is attached
+  Scenario: Attaching PNG images
+    When a PNG image is attached
 
-  Scenario: Attaching a document with a different filename
+  Scenario: Attaching PDFs with a different filename
     When a PDF document is attached and renamed

--- a/devkit/samples/attachments/attachments.feature
+++ b/devkit/samples/attachments/attachments.feature
@@ -36,5 +36,13 @@ Feature: Attachments
   Scenario: Attaching PNG images
     When a PNG image is attached
 
+  Scenario Outline: Attaching images in an examples table
+    When a <type> image is attached
+
+    Examples:
+      | type |
+      | JPEG |
+      | PNG  |
+
   Scenario: Attaching PDFs with a different filename
     When a PDF document is attached and renamed

--- a/devkit/samples/attachments/attachments.feature
+++ b/devkit/samples/attachments/attachments.feature
@@ -34,11 +34,7 @@ Feature: Attachments
     When a JPEG image is attached
 
   Scenario: Attaching images in examples
-    When the <image> png is attached
-
-    Examples:
-      | image        |
-      | cucumber.png |
+    When the cucumber.png png is attached
 
   Scenario: Attaching a document with a different filename
     When a PDF document is attached and renamed

--- a/devkit/samples/attachments/attachments.feature
+++ b/devkit/samples/attachments/attachments.feature
@@ -15,17 +15,17 @@ Feature: Attachments
 
     When the string "hello" is attached as "application/octet-stream"
 
+  Scenario: Log text
+    When the string "hello" is logged
+
+  Scenario: Log ANSI coloured text
+    When text with ANSI escapes is logged
+
   Scenario: Log JSON
      When the following string is attached as "application/json":
        ```
        {"message": "The <b>big</b> question", "foo": "bar"}
        ```
-
-  Scenario: Log text
-    When the string "hello" is logged
-
-  Scenario: Log ANSI coloured text
-     When text with ANSI escapes is logged
 
   Scenario: Byte arrays are base64-encoded regardless of media type
     When an array with 10 bytes is attached as "text/plain"

--- a/devkit/samples/attachments/attachments.feature.ts
+++ b/devkit/samples/attachments/attachments.feature.ts
@@ -1,6 +1,10 @@
 import { Before, When } from '@cucumber/fake-cucumber'
 import fs from 'fs'
 
+// Cucumber-JVM needs to use a Before hook in order to create attachments
+// NB: We should probably try to remove this
+Before(() => undefined)
+
 When('the string {string} is attached as {string}', function (text: string, mediaType: string) {
   this.attach(text, mediaType)
 })

--- a/devkit/samples/attachments/attachments.feature.ts
+++ b/devkit/samples/attachments/attachments.feature.ts
@@ -1,9 +1,5 @@
 import { Before, When } from '@cucumber/fake-cucumber'
-import { ReadableStreamBuffer } from 'stream-buffers'
 import fs from 'fs'
-
-// Cucumber-JVM needs to use a Before hook in order to create attachments
-Before(() => undefined)
 
 When('the string {string} is attached as {string}', function (text: string, mediaType: string) {
   this.attach(text, mediaType)
@@ -29,19 +25,6 @@ When(
     const data = [...Array(size).keys()]
     const buffer = Buffer.from(data)
     this.attach(buffer, mediaType)
-  }
-)
-
-When(
-  'a stream with {int} bytes are attached as {string}',
-  async function (size: number, mediaType: string) {
-    const data = [...Array(size).keys()]
-    const buffer = Buffer.from(data)
-    const stream = new ReadableStreamBuffer({ chunkSize: 1, frequency: 1 })
-    stream.put(buffer)
-    stream.stop()
-
-    await this.attach(stream, mediaType)
   }
 )
 

--- a/devkit/samples/attachments/attachments.feature.ts
+++ b/devkit/samples/attachments/attachments.feature.ts
@@ -32,8 +32,8 @@ When('a JPEG image is attached', async function () {
   await this.attach(fs.createReadStream(__dirname + '/cucumber.jpeg'), 'image/jpeg')
 })
 
-When('the {word} png is attached', async function (filename) {
-  await this.attach(fs.createReadStream(__dirname + `/${filename}`), 'image/png')
+When('a PNG image is attached', async function () {
+  await this.attach(fs.createReadStream(__dirname + '/cucumber.png'), 'image/png')
 })
 
 When('a PDF document is attached and renamed', async function () {

--- a/ruby/features/attachments/attachments.feature.rb
+++ b/ruby/features/attachments/attachments.feature.rb
@@ -25,8 +25,8 @@ When('a JPEG image is attached') do
   attach(File.open("#{__dir__}/cucumber.jpeg"), 'image/jpeg')
 end
 
-When('the {word} png is attached') do |filename|
-  attach(File.open("#{__dir__}/#{filename}"), 'image/png')
+When('a PNG image is attached') do
+  attach(File.open("#{__dir__}/cucumber.png"), 'image/png')
 end
 
 When('a PDF document is attached and renamed') do

--- a/ruby/features/attachments/attachments.feature.rb
+++ b/ruby/features/attachments/attachments.feature.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require 'stringio'
-
-# Cucumber-JVM needs to use a Before hook in order to create attachments
-Before { nil }
-
 When('the string {string} is attached as {string}') do |text, media_type|
   attach(text, media_type)
 end
@@ -24,13 +19,6 @@ end
 When('an array with {int} bytes is attached as {string}') do |size, media_type|
   data = (0..size-1).map { |i| [i].pack('C') }.join
   attach(data, media_type)
-end
-
-When('a stream with {int} bytes are attached as {string}') do |size, media_type|
-  stream = StringIO.new
-  stream.puts (0..size).map(&:to_s).join('')
-  stream.seek(0)
-  attach(stream, media_type)
 end
 
 When('a JPEG image is attached') do

--- a/ruby/features/attachments/attachments.feature.rb
+++ b/ruby/features/attachments/attachments.feature.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# Cucumber-JVM needs to use a Before hook in order to create attachments
+# NB: We should probably try to remove this
+Before { nil }
+
 When('the string {string} is attached as {string}') do |text, media_type|
   attach(text, media_type)
 end


### PR DESCRIPTION
### 🤔 What's changed?

`attachments` are now is consistent for ruby/js.

### ⚡️ What's your motivation? 

Goes towards completion of issue in tracker

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

Do we need to fix anything else (I'm deliberately not regenerating the ndjson yet because there are a bunch of these that will need re-generating each time). 

To avoid conflicts I'll re-generate once after merging several of these fixes

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
