### PR TITLE
CCK: Reconcile data tables

### DIFF
--- a/devkit/samples/cdata/cdata.feature
+++ b/devkit/samples/cdata/cdata.feature
@@ -1,5 +1,4 @@
 Feature: cdata
-  
   Cucumber xml formatters should be able to handle xml cdata elements
 
   Scenario: cdata

--- a/devkit/samples/data-tables/data-tables.feature
+++ b/devkit/samples/data-tables/data-tables.feature
@@ -1,7 +1,8 @@
 Feature: Data Tables
-  Data Tables can be places underneath a step and will be passed as the last
-  argument to the step definition. They can be used to represent richer data
-  structures, and can also be transformed to other types.
+  Data Tables can be placed underneath a step and will be passed as the last
+  argument to the step definition.
+
+  They can be used to represent richer data structures, and can be transformed to other data-types.
 
   Scenario: transposed table
     When the following table is transposed:


### PR DESCRIPTION
`data-tables` are now is consistent for ruby/js. EDIT: No code change here out of feature

### ⚡️ What's your motivation? 

Goes towards completion of issue in tracker

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
