### PR TITLE
CCK: Reconcile examples tables

### DIFF
--- a/devkit/samples/examples-tables/examples-tables.feature
+++ b/devkit/samples/examples-tables/examples-tables.feature
@@ -1,10 +1,9 @@
 Feature: Examples Tables
-  Sometimes it can be desireable to run the same scenario multiple times
-  with different data each time. This can be done by placing an Examples
-  section with an Examples Table underneath a Scenario, and use <placeholders>
-  in the Scenario, matching the table headers.
+  Sometimes it can be desirable to run the same scenario multiple times with
+  different data each time - this can be done by placing an Examples table underneath
+  a Scenario, and use <placeholders> in the Scenario which match the table headers.
 
-  Scenario Outline: eating cucumbers
+  Scenario Outline: Eating cucumbers
     Given there are <start> cucumbers
     When I eat <eat> cucumbers
     Then I should have <left> cucumbers


### PR DESCRIPTION
`examples-tables` are now is consistent for ruby/js. EDIT: No code change here out of feature

### ⚡️ What's your motivation? 

Goes towards completion of issue in tracker

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
