### PR TITLE
CCK: Reconcile parameter types

### DIFF
--- a/devkit/samples/parameter-types/parameter-types.feature
+++ b/devkit/samples/parameter-types/parameter-types.feature
@@ -1,9 +1,11 @@
 Feature: Parameter Types
   Cucumber lets you define your own parameter types, which can be used
-  in Cucumber Expressions. This lets you define a precise domain-specific
-  vocabulary which can be used to generate a glossary with examples taken
-  from your scenarios. They also let you transform strings and tables into
-  rich types.
+  in Cucumber Expressions.
 
-  Scenario: flights
-    Given LHR-CDG has been delayed 45 minutes
+  This lets you define a precise domain-specific vocabulary which can be used to
+  generate a glossary with examples taken from your scenarios.
+
+  Parameter types also enable you to transform strings and tables into different types.
+
+  Scenario: Flight transformer
+    Given LHR-CDG has been delayed

--- a/devkit/samples/parameter-types/parameter-types.feature.ts
+++ b/devkit/samples/parameter-types/parameter-types.feature.ts
@@ -13,8 +13,7 @@ ParameterType({
   },
 })
 
-Given('{flight} has been delayed {int} minutes', function (flight: Flight, delay: number) {
+Given('{flight} has been delayed', function (flight: Flight) {
   assert.strictEqual(flight.from, 'LHR')
   assert.strictEqual(flight.to, 'CDG')
-  assert.strictEqual(delay, 45)
 })

--- a/ruby/features/parameter-types/parameter-types.feature.rb
+++ b/ruby/features/parameter-types/parameter-types.feature.rb
@@ -15,8 +15,7 @@ ParameterType(
   transformer: ->(from, to) { Flight.new(from, to) }
 )
 
-Given('{flight} has been delayed {int} minutes') do |flight, delay|
+Given('{flight} has been delayed') do |flight|
   expect(flight.from).to eq('LHR')
   expect(flight.to).to eq('CDG')
-  expect(delay).to eq(45)
 end


### PR DESCRIPTION
`parameter-types` is now is consistent for ruby/js.

### ⚡️ What's your motivation? 

Goes towards completion of issue in tracker

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
