### PR TITLE
CCK: Reconcile pending

### DIFF
--- a/devkit/samples/pending/pending.feature
+++ b/devkit/samples/pending/pending.feature
@@ -8,12 +8,12 @@ Feature: Pending steps
   result to be treated as a failure.
 
   Scenario: Unimplemented step signals pending status
-    Given a step that isnt implemented yet
+    Given an unimplemented pending step
 
   Scenario: Steps before unimplemented steps are executed
-    Given an implemented step
-    When a step that isnt implemented yet
+    Given an implemented non-pending step
+    And an unimplemented pending step
 
   Scenario: Steps after unimplemented steps are skipped
-    Given a step that isnt implemented yet
-    Then a step that we expect to be skipped
+    Given an unimplemented pending step
+    And an implemented step that is skipped

--- a/devkit/samples/pending/pending.feature.ts
+++ b/devkit/samples/pending/pending.feature.ts
@@ -1,13 +1,13 @@
 import { Given } from '@cucumber/fake-cucumber'
 
-Given('an implemented step', function () {
+Given('an implemented non-pending step', function () {
   // no-op
 })
 
-Given('a step that isnt implemented yet', function () {
+Given('an implemented step that is skipped', function () {
+  // no-op
+})
+
+Given('an unimplemented pending step', function () {
   return 'pending'
-})
-
-Given('a step that we expect to be skipped', function () {
-  // no-op
 })

--- a/ruby/features/pending/pending.feature.rb
+++ b/ruby/features/pending/pending.feature.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-Given('an implemented step') do
+Given('an implemented non-pending step') do
   # no-op
 end
 
-Given('a step that we expect to be skipped') do
+Given('an implemented step that is skipped') do
   # no-op
 end
 
-Given('a step that isnt implemented yet') do
+Given('an unimplemented pending step') do
   'pending'
 end

--- a/ruby/features/pending/pending.feature.rb
+++ b/ruby/features/pending/pending.feature.rb
@@ -9,5 +9,5 @@ Given('an implemented step that is skipped') do
 end
 
 Given('an unimplemented pending step') do
-  'pending'
+  pending('')
 end


### PR DESCRIPTION
`pending` is now is consistent for ruby/js.

### ⚡️ What's your motivation? 

Goes towards completion of issue in tracker

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
