### PR TITLE
CCK: Reconcile retry

### DIFF
--- a/devkit/samples/retry/retry.feature
+++ b/devkit/samples/retry/retry.feature
@@ -1,22 +1,21 @@
 Feature: Retry
-
   Some Cucumber implementations support a Retry mechanism, where test cases that fail
   can be retried up to a limited number of attempts in the same test run.
 
-  Non-passing statuses other than FAILED don't trigger a retry - they are not going to pass
-  however many times we attempt them.
+  Non-passing statuses other than FAILED won't trigger a retry, as they are not
+  going to pass however many times we attempt them.
 
-  Scenario: test case passes on the first attempt
+  Scenario: Test cases that pass aren't retried
     Given a step that always passes
 
-  Scenario: test case passes on the second attempt
+  Scenario: Test cases that fail are retried if within the --retry limit
     Given a step that passes the second time
 
-  Scenario: test case passes on the final attempt
+  Scenario: Test cases that fail will continue to retry up to the --retry limit
     Given a step that passes the third time
 
-  Scenario: test case fails on every attempt
+  Scenario: Test cases won't retry after failing more than the --retry limit
     Given a step that always fails
 
-  Scenario: don't retry on UNDEFINED
+  Scenario: Test cases won't retry when the status is UNDEFINED
     Given a non-existent step

--- a/ruby/features/retry/retry.feature.rb
+++ b/ruby/features/retry/retry.feature.rb
@@ -7,15 +7,15 @@ end
 second_time_pass = 0
 Given('a step that passes the second time') do
   second_time_pass += 1
-  raise StandardError, 'Exception in step' if second_time_pass < 2
+  raise 'Exception in step' if second_time_pass < 2
 end
 
 third_time_pass = 0
 Given('a step that passes the third time') do
   third_time_pass += 1
-  raise StandardError, 'Exception in step' if third_time_pass < 3
+  raise 'Exception in step' if third_time_pass < 3
 end
 
 Given('a step that always fails') do
-  raise StandardError, 'Exception in step'
+  raise 'Exception in step'
 end


### PR DESCRIPTION
`retry` is now is consistent for ruby (No JS changes needed).

### ⚡️ What's your motivation? 

Goes towards completion of issue in tracker

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)
- :bug: Bug fix (non-breaking change which fixes a defect)
- 
### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
