### PR TITLE
hotfix: Avoid confusing path situation where no CCK tests are found

### DIFF
--- a/ruby/lib/cck/examples.rb
+++ b/ruby/lib/cck/examples.rb
@@ -4,23 +4,23 @@ module CCK
   module Examples
     class << self
       def gherkin
-        Dir.entries(features_folder_location).select do |file_or_folder|
+        Dir.entries(cck_features_folder_location).select do |file_or_folder|
           next if file_or_folder.start_with?('.')
 
-          gherkin_example?(File.join(features_folder_location, file_or_folder))
+          gherkin_example?(File.join(cck_features_folder_location, file_or_folder))
         end
       end
 
       def markdown
-        Dir.entries(features_folder_location).select do |file_or_folder|
+        Dir.entries(cck_features_folder_location).select do |file_or_folder|
           next if file_or_folder.start_with?('.')
 
-          markdown_example?(File.join(features_folder_location, file_or_folder))
+          markdown_example?(File.join(cck_features_folder_location, file_or_folder))
         end
       end
 
       def feature_code_for(example_name)
-        path = File.join(features_folder_location, example_name)
+        path = File.join(cck_features_folder_location, example_name)
 
         return path if File.directory?(path)
 
@@ -29,7 +29,7 @@ module CCK
 
       private
 
-      def features_folder_location
+      def cck_features_folder_location
         File.expand_path("#{File.dirname(__FILE__)}/../../features/")
       end
 


### PR DESCRIPTION


### 🤔 What's changed?

The way ruby is autoloading code it's causing a method conflict. So just use 2 diff names.

### ⚡️ What's your motivation? 

We want to have the same namespace (Although maybe we shouldn't). So for now this will load the path in 2 diff ways (Intended)

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
