### PR TITLE
Remove redundant devkit copy step for ruby test

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   test-ruby:
+    defaults:
+      working-directory: ruby
     strategy:
       fail-fast: false
       matrix:
@@ -25,14 +27,5 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
           rubygems: latest
-          working-directory: ruby
-      - uses: actions/setup-node@v4
-        with:
-          cache: 'npm'
-          cache-dependency-path: devkit/package-lock.json
-      - name: Copy the samples to ruby/features
-        run: npm ci && npm run copy-to:ruby
-        working-directory: devkit
       - name: Run tests
         run: bundle exec rspec
-        working-directory: ruby


### PR DESCRIPTION
### 🤔 What's changed?

Remove the `npm run copy-to:ruby` step.  It is not necessary during test.

