### PR TITLE
Use Trusted Publishing for Ruby

### DIFF
--- a/.github/workflows/release-rubygem.yml
+++ b/.github/workflows/release-rubygem.yml
@@ -12,6 +12,8 @@ jobs:
     name: Publish Ruby Gem
     runs-on: ubuntu-latest
     environment: Release
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -27,7 +29,6 @@ jobs:
       - name: Copy the samples to ruby/features
         run: npm ci && npm run copy-to:ruby
         working-directory: devkit
-      - uses: cucumber/action-publish-rubygem@d8918cbdee789cfc78f346a96a59596b87795be1 # v1.0.0
+      - uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0
         with:
-          working_directory: ruby
-          rubygems_api_key: ${{ secrets.RUBYGEMS_API_KEY }}
+          working-directory: ruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- [Ruby] Fix release process
 
 ## [29.1.4] - 2026-02-24
 ### Fixed


### PR DESCRIPTION
### ⚡️ What's your motivation? 

Work towards closing https://github.com/cucumber/common/issues/2277.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### 📋 Checklist:

- [x] Remove `RUBYGEMS_API_KEY` from secrets
- [x] Remove API Key configuration from Rubygems
- [x] Configure trusted publisher in Rubygems
- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
