### PR TITLE
Do not allow Git to change line endings in SVG images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- [Devkit] Do not allow git to change line endings in SVG images ([#125](https://github.com/cucumber/compatibility-kit/pull/125))
 
 ## [18.0.1] - 2025-02-24
 ### Fixed
@@ -13,7 +15,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [18.0.0] - 2025-02-24
 ### Changed
-- 
 - [Devkit] Slice hook and attachment samples more thinly ([#122](https://github.com/cucumber/compatibility-kit/pull/122))
 
 ## [17.0.1] - 2025-01-29

--- a/devkit/samples/hooks-attachment/.gitattributes
+++ b/devkit/samples/hooks-attachment/.gitattributes
@@ -1,0 +1,4 @@
+# SVG files are plain text. So git will change line endings on windows.
+# Because we expect the image to have been encoded in base64 with lf rather than
+# crlf this is not desirable.
+cucumber.svg eol=lf


### PR DESCRIPTION
### 🤔 What's changed?

Inform git that line endings in `cucumber.svg` should not be changed. 

### ⚡️ What's your motivation? 

SVG files are plain text. So git will change line endings on windows.
Because we expect the image to have been encoded in base64 with `lf` rather than
`crlf` this is not desirable.

See for example: https://github.com/cucumber/cucumber-jvm/actions/runs/13509886103/job/37747778780?pr=2977

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)


### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
