### PR TITLE
Simplify CI by removing pre-release checks

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -6,12 +6,8 @@ on:
       - release/*
 
 jobs:
-  pre-release-check:
-    uses: cucumber/.github/.github/workflows/prerelease-checks.yml@main
-
   create-github-release:
     name: Create Git tag and GitHub Release
-    needs: [pre-release-check]
     runs-on: ubuntu-latest
     environment: Release
     permissions:

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -9,12 +9,8 @@ permissions:
   contents: read
 
 jobs:
-  pre-release-check:
-    uses: cucumber/.github/.github/workflows/prerelease-checks.yml@main
-    
   publish-npm:
     name: Publish NPM module
-    needs: [pre-release-check]
     runs-on: ubuntu-latest
     environment: Release
     steps:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -6,15 +6,8 @@ on:
       - release/*
 
 jobs:
-  pre-release-check:
-    uses: cucumber/.github/.github/workflows/prerelease-checks.yml@main
-
-  test-ruby:
-    uses: ./.github/workflows/test-ruby.yml
-
   publish-rubygem:
     name: Publish Ruby Gem
-    needs: [pre-release-check, test-ruby]
     runs-on: ubuntu-latest
     environment: Release
     steps:


### PR DESCRIPTION
### ⚡️ What's your motivation? 

We don't consistently use pre-release checks and the check only checks if the commit is also on main. In case we do a hotfix on a release branch, this might not be what we want.

