### PR TITLE
fix: Build Python package before publishing

### DIFF
--- a/.github/workflows/release-pypi.yaml
+++ b/.github/workflows/release-pypi.yaml
@@ -30,6 +30,10 @@ jobs:
         run: npm ci && npm run copy-to:python
         working-directory: devkit
 
+      - name: Build package
+        working-directory: python
+        run: uv build
+
       - name: Publish package
         working-directory: python
         run: uv publish


### PR DESCRIPTION
### 🤔 What's changed?

Added missing build step in Python publish workflow.

### ⚡️ What's your motivation? 

Fixes failing [Python publish workflow](https://github.com/cucumber/compatibility-kit/actions/runs/18562137096) arising from #113 - following a direct replacement of the archived [cucumber/action-publish-pypi](https://github.com/cucumber/action-publish-pypi) "publish" step - which was also building the package; with uv's publish command; without introducing the uv build command.

Aligns with all Python release workflows within Cucumber (see [gherkin](https://github.com/cucumber/cucumber-expressions/blob/f82ea4b8df186fc0f6438c5fed6d145f370d79bb/.github/workflows/release-pypi.yaml#L27-L31)).

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)

### ♻️ Anything particular you want feedback on?

- Quick check whether looks good.

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)