### PR TITLE
java: Read devkit samples directly

### DIFF
--- a/.github/workflows/release-mvn.yml
+++ b/.github/workflows/release-mvn.yml
@@ -11,14 +11,6 @@ jobs:
     environment: Release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version: '24.x'
-          cache: "npm"
-          cache-dependency-path: devkit/package-lock.json
-      - name: Copy the samples to java/../features
-        run: npm ci && npm run copy-to:java
-        working-directory: devkit
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -22,14 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
-        with:
-          node-version: '24.x'
-          cache: "npm"
-          cache-dependency-path: devkit/package-lock.json
-      - name: Copy the samples to java/../features
-        run: npm ci && npm run copy-to:java
-        working-directory: devkit
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: 'temurin'

--- a/devkit/package.json
+++ b/devkit/package.json
@@ -6,10 +6,9 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "copy-samples": "npm run copy-to:javascript && npm run copy-to:ruby && npm run copy-to:java",
+    "copy-samples": "npm run copy-to:javascript && npm run copy-to:ruby",
     "copy-to:javascript": "shx cp -r samples/* ../javascript/features",
     "copy-to:ruby": "shx cp -r samples/* ../ruby/features && rm -rf ../ruby/features/**/*.ts",
-    "copy-to:java": "shx cp -r samples/* ../java/src/main/resources/io/cucumber/compatibilitykit/features && rm -rf ../java/src/main/resources/io/cucumber/compatibilitykit/features/**/*.ts",
     "copy-to:python": "shx cp -r samples/* ../python/src/cucumber_compatibility_kit/features && rm -rf ../python/src/cucumber_compatibility_kit/features/**/*.ts",
     "fix": "eslint --max-warnings 0 src test --fix && prettier --write src test",
     "generate": "vitest run --update",

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -68,7 +68,23 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>../devkit/samples</directory>
+                <excludes>
+                    <exclude>*.ts</exclude>
+                </excludes>
+            </resource>
+        </resources>
+
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <configuration>
+                    <outputDirectory>${build.outputDirectory}/io/cucumber/compatibilitykit/features</outputDirectory>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>

--- a/java/src/main/resources/io/cucumber/compatibilitykit/features/.gitignore
+++ b/java/src/main/resources/io/cucumber/compatibilitykit/features/.gitignore
@@ -1,2 +1,0 @@
-# Do not commit CCK examples
-*/*.*


### PR DESCRIPTION

### ⚡️ What's your motivation? 

Instead of using node to copy the samples, we can read them directly from the devkit/samples folder. This removes the dependency on npm from the build processes

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)


### 📋 Checklist:
- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
