### PR TITLE
DotNet: Promote version property to solution

### DIFF
--- a/.github/workflows/release-nuget.yaml
+++ b/.github/workflows/release-nuget.yaml
@@ -14,10 +14,10 @@ jobs:
       - uses: actions/setup-dotnet@baa11fbfe1d6520db94683bd5c7a3818018e4309 # v5.1.0
         with:
           dotnet-version: 10.0.x
-        # Setup local NUGET source
       - name: Setup local NUGET source
-        run: mkdir -p ./dotnet/Cucumber.CCK/bin/Release/NuGet
+        run: mkdir -p ./bin/Release/NuGet
+        working-directory: dotnet/Cucumber.CCK
       - uses: cucumber/action-publish-nuget@f059d15b2dbcd962afc0d29424f4f083177255aa # v1.0.0
         with:
           nuget-api-key: ${{ secrets.NUGET_API_KEY }}
-          working-directory: "dotnet"
+          working-directory: "dotnet/Cucumber.CCK"

--- a/dotnet/Cucumber.CCK.Tests/Cucumber.CCK.Tests.csproj
+++ b/dotnet/Cucumber.CCK.Tests/Cucumber.CCK.Tests.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <!-- This will resolve from local source after packing -->
-    <PackageReference Include="Cucumber.CCK" Version="27.0.0" />
+    <PackageReference Include="Cucumber.CCK" Version="$(Version)" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/Cucumber.CCK/Cucumber.CCK.csproj
+++ b/dotnet/Cucumber.CCK/Cucumber.CCK.csproj
@@ -24,13 +24,6 @@
     <PackageOutputPath>bin/$(Configuration)/NuGet</PackageOutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Label="Version">
-    <VersionNumber>29.1.2</VersionNumber>
-    <Version Condition="'$(SnapshotSuffix)' != ''">$(VersionNumber)-$(SnapshotSuffix)</Version>
-    <Version Condition="'$(SnapshotSuffix)' == ''">$(VersionNumber)</Version>
-  </PropertyGroup>
-
-
   <ItemGroup>
     <None Include="$(MSBuildThisFileDirectory)\Resources\cucumber-mark-green-128.png">
       <Pack>True</Pack>

--- a/dotnet/Directory.Build.props
+++ b/dotnet/Directory.Build.props
@@ -3,4 +3,11 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  
+  <PropertyGroup Label="Version">
+    <VersionNumber>29.1.2</VersionNumber>
+    <Version Condition="'$(SnapshotSuffix)' != ''">$(VersionNumber)-$(SnapshotSuffix)</Version>
+    <Version Condition="'$(SnapshotSuffix)' == ''">$(VersionNumber)</Version>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION

### 🤔 What's changed?

Moved the Version property setter from the CCK csproj to the Directory.Build.props file. This allows the Test project to know which version of the nuget package to reference.

### ⚡️ What's your motivation? 

This should resolve the problem of the test workflow failing to resolve the correct version of the nuget package.

### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)


### ♻️ Anything particular you want feedback on?

<!-- 
Is there anything in this change you're unsure about, or would 
particularly like reviewers to give you feedback on?
-->

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
