### PR TITLE
Enhancing project packaging to allow consumers to override the delivery path of CCK content.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+/dotnet/Cucumber.CCK.Tests.AltPath

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- [.Net] Added Property settings to allow consumers to override the path where CCK assets are delivered.
 
 ## [29.1.3] - 2026-02-17
 ### Fixed

--- a/dotnet/Cucumber.CCK.slnx
+++ b/dotnet/Cucumber.CCK.slnx
@@ -1,4 +1,8 @@
 <Solution>
+  <Folder Name="/Solution Items/">
+    <File Path="Directory.Build.props" />
+    <File Path="NuGet.Config" />
+  </Folder>
   <Project Path="Cucumber.CCK.Tests/Cucumber.CCK.Tests.csproj" />
   <Project Path="Cucumber.CCK/Cucumber.CCK.csproj" />
 </Solution>

--- a/dotnet/Cucumber.CCK/Cucumber.CCK.csproj
+++ b/dotnet/Cucumber.CCK/Cucumber.CCK.csproj
@@ -36,7 +36,6 @@
       <PackagePath>contentFiles\any\any\cck\samples\%(RecursiveDir)%(Filename)%(Extension)</PackagePath>
       <Pack>true</Pack>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <PackageCopyToOutput>true</PackageCopyToOutput>
     </Content>
   </ItemGroup>
   <ItemGroup>
@@ -52,6 +51,11 @@
 
   <ItemGroup>
     <Folder Include="Resources\"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="build\Cucumber.CCK.props" Pack="true" PackagePath="build\" />
+    <None Include="build\Cucumber.CCK.targets" Pack="true" PackagePath="build\" />
   </ItemGroup>
 
 </Project>

--- a/dotnet/Cucumber.CCK/README.md
+++ b/dotnet/Cucumber.CCK/README.md
@@ -38,6 +38,23 @@ Install-Package Cucumber.CCK
 
 The compatibility kit packages gherkin files and sample data as content files that are automatically copied to your output directory when you reference the package. The files will be available in the `cck/samples/` directory relative to your output folder.
 
+### Customizing the Content Path
+
+You can change where the CCK files appear in your project by setting the `CucumberCCKContentPath` MSBuild property in your project file:
+
+```xml
+<PropertyGroup>
+   <CucumberCCKContentPath>TestData\CCK</CucumberCCKContentPath>
+</PropertyGroup>
+```
+
+If not set, the default value is `cck\samples`.
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `CucumberCCKContentPath` | `cck\samples` | Relative path where CCK content appears in the project and is copied to the output directory |
+
+
 ## More Info
 
 The Cucumber Compatibility Kit is part of the development tools of [Cucumber](https://cucumber.io). It helps ensure that all implementations are properly supporting our internal protocol and are compatible (and consistent) with each other and our common tools like the [html-formatter](https://github.com/cucumber/html-formatter).

--- a/dotnet/Cucumber.CCK/build/Cucumber.CCK.props
+++ b/dotnet/Cucumber.CCK/build/Cucumber.CCK.props
@@ -1,0 +1,6 @@
+<Project>
+  <PropertyGroup>
+    <!-- Default path - consumers can override this -->
+    <CucumberCCKContentPath Condition="'$(CucumberCCKContentPath)' == ''">cck\samples</CucumberCCKContentPath>
+  </PropertyGroup>
+</Project>

--- a/dotnet/Cucumber.CCK/build/Cucumber.CCK.targets
+++ b/dotnet/Cucumber.CCK/build/Cucumber.CCK.targets
@@ -1,0 +1,12 @@
+<Project>
+  <ItemGroup>
+    <!-- Remove NuGet auto-generated contentFiles items -->
+    <Content Remove="$(MSBuildThisFileDirectory)..\contentFiles\any\any\cck\samples\**\*" />
+
+    <!-- Add them back with configurable path -->
+    <Content Include="$(MSBuildThisFileDirectory)..\contentFiles\any\any\cck\samples\**\*"
+             Link="$(CucumberCCKContentPath)\%(RecursiveDir)%(Filename)%(Extension)"
+             CopyToOutputDirectory="PreserveNewest"
+             Visible="true" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
### 🤔 What's changed?

Added an MSBuild property `<CucumberCCKContentPath>` with a default value of 'cck\samples'. Consuming .Net projects can override this property to customize where in their project structure the CCK assets should appear.

### ⚡️ What's your motivation? 

Ease of consumption.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?



### 📋 Checklist:



- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [X] My change requires a change to the documentation.
  - [X] I have updated the documentation accordingly.
- [X] Users should know about my change
  - [X] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
